### PR TITLE
catch exception when reading repositories

### DIFF
--- a/scan-registry.py
+++ b/scan-registry.py
@@ -86,7 +86,12 @@ for p in projects:
         logging.info('⏩ Skip archived "%s"', p.name)
         continue
 
-    repositories = p.repositories.list(all=True)
+    try:
+        repositories = p.repositories.list(all=True)
+    except Exception:
+        logging.info('🔦 Exception reading repositories for "%s"', p.name)
+        continue
+    
     if repositories:
         for r in repositories:  
             tags = r.tags.list(all=True)


### PR DESCRIPTION
In our instance in some projects the repositories could not be loaded. This kept the script from displaying the total calculated size at the end. This PR catches the exception when reading the repositories and just moves on to the next project